### PR TITLE
Add more specific error message

### DIFF
--- a/projects/ngx-translate/multi-http-loader/src/lib/multi-http-loader.ts
+++ b/projects/ngx-translate/multi-http-loader/src/lib/multi-http-loader.ts
@@ -20,7 +20,8 @@ export class MultiTranslateHttpLoader implements TranslateLoader {
     const requests = this.resources.map(resource => {
       const path = resource.prefix + lang + resource.suffix;
       return this.http.get(path).pipe(catchError(res => {
-        console.error("Could not find translation file:", path);
+        console.error("Something went wrong for the following translation file:", path);
+        console.error(res.message);
         return of({});
       }));
     });


### PR DESCRIPTION
I was spending quite some time figuring out why it couldn't find the file when it actually was there. Turned out it was a parsing error.

So I changed the error message to be a bit more specific depending on the response it gets.